### PR TITLE
Update humancar.launch

### DIFF
--- a/launch/humancar.launch
+++ b/launch/humancar.launch
@@ -26,7 +26,7 @@ output="screen" ns="/$(arg robot_name)" args="joint1_velocity_controller joint2_
 </node>
 
 <!-- needed in order to accept cmd_vel inputs to drive the car -->
-<node name="cmdvel2gazebo$(arg robot_name)" pkg="cmdvel2gazebo" type="cmdvel2gazebo_node" respawn="false" output="screen"> 
+<node name="cmdvel2gazebo$(arg robot_name)" pkg="catvehicle" type="cmdvel2gazebo.py" respawn="false" output="screen">
 <!-- remap the topics to match our robot's name and namespace -->
 <remap from="/catvehicle/cmd_vel" to="/$(arg robot_name)/cmd_vel" />
 <remap from="/catvehicle/joint1_velocity_controller/command" to="/$(arg robot_name)/joint1_velocity_controller/command" />


### PR DESCRIPTION
Simulink Version of cmdvel2gazebo has hard coded azcar_sim and somehow doesn't work with a humancar. Hence I am replacing simulink version of cmdvel2gazebo with py version. This change is already present in catvehicle.launch